### PR TITLE
Make pod anti affinity configurable

### DIFF
--- a/manifests/mongodb.json
+++ b/manifests/mongodb.json
@@ -136,8 +136,9 @@
 		"spec": {
 			"mongodb": {
 				"replicas": 3,
-				"mongodb_limit_cpu": "500m",
-				"mongodb_limit_memory": "256Mi"
+				"mongodb_limit_cpu": "100m",
+				"mongodb_limit_memory": "128Mi",
+				"hard_pod_anti_affinity": false
 			}
 		}
 	}]


### PR DESCRIPTION
Currently the operator enforces hard anti affinity. This makes it
hard to use on Minikube, which also makes integration testing very
difficult.

With the `spec->mongodb->hard_pod_anti_affinity` set to False, the
operator will use `preferredDuringSchedulingIgnoredDuringExecution`
instead of `requiredDuringSchedulingIgnoredDuringExecution`.

`requiredDuringSchedulingIgnoredDuringExecution` stays the default.